### PR TITLE
Fix bug message should come from bitbucket bot not slackbot

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -141,22 +141,26 @@ func (w WebhookBody) FormatMessage(msg string, action string) []slack.MsgOption 
 		color = "#B8C043"
 	}
 
-	project := w.PullRequest.ToRef.Repository.Project.Key
-	repoSlug := w.PullRequest.ToRef.Repository.Slug
-	repoAsUsername := fmt.Sprintf("%s (%s) bitbucket", repoSlug, project)
+	authorName := fmt.Sprintf(
+		"%s (%s)\n%s %s",
+		w.PullRequest.ToRef.Repository.Project.Key,
+		w.PullRequest.ToRef.Repository.Slug,
+		w.Actor.DisplayName,
+		action,
+	)
 
 	title := fmt.Sprintf("PR #%d: %s", w.PullRequest.ID, w.PullRequest.Title)
 
 	attachment := slack.Attachment{
+		AuthorName: authorName,
 		Color:      color,
 		Text:       msg,
 		Title:      title,
 		TitleLink:  w.GetPrURL(),
-		AuthorName: w.Actor.DisplayName + " " + action,
 	}
 
 	return []slack.MsgOption{
 		slack.MsgOptionAttachments(attachment),
-		slack.MsgOptionUsername(repoAsUsername),
+		slack.MsgOptionAsUser(true),
 	}
 }


### PR DESCRIPTION
Revert override Username, otherwise message comes from Slackbot.

Prepend AuthorName with repo slug and project instead.

```
bitbucket:
| the-repo-slug (PROJ)
| Foo Bar opened pull request
| [PR #42: Title of pull request here](link to pr)
| is waiting for your review
```