### PR TITLE
feat: notify thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # bitbucket-slack-bot
 
-This bot tries its best to only send messages about pull requests that can be act apon.
-For example notify author if we have at least 2 approvers. 
+This bot tries its best to only send messages about pull requests that can be acted upon.
+For example notify author if we have at least 2 approvers.
 
-
-# Setup
+## Setup
 
 Configure webhooks for your repo to go to `http://bot-url/webhook`. All event's Pull request category should be checked.
 
-# Running
+## Running tests
+
+`go test -v ./...`
+
+## Running
 
 ```
 Usage of bitbucket-slack-bot:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fortnoxab/bitbucket-slack-bot
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fortnoxab/fnxlogrus v0.0.0-20181213065106-cbb7cf837eba

--- a/models/merge.go
+++ b/models/merge.go
@@ -2,7 +2,7 @@ package models
 
 /*example
 TODO implement this
-curl -su user https://git/rest/api/1.0/projects/FNX/repos/bank-transactions-fetcher/pull-requests/136/merge
+curl https://git/rest/api/1.0/projects/FNX/repos/bank-transactions-fetcher/pull-requests/136/merge
 
 {
   "canMerge": false,
@@ -18,7 +18,6 @@ curl -su user https://git/rest/api/1.0/projects/FNX/repos/bank-transactions-fetc
 
 */
 
-//
 type Merge struct {
 	CanMerge   bool   `json:"canMerge"`
 	Conflicted bool   `json:"conflicted"`

--- a/models/pr_activity.go
+++ b/models/pr_activity.go
@@ -1,0 +1,132 @@
+package models
+
+/*example
+
+curl https://git/rest/api/1.0/projects/FNX/repos/vessel/pull-requests/2436/activities
+
+*/
+
+type Activities struct {
+	Size       int  `json:"size"`
+	Limit      int  `json:"limit"`
+	IsLastPage bool `json:"isLastPage"`
+	Values     []struct {
+		ID          int   `json:"id"`
+		CreatedDate int64 `json:"createdDate"`
+		User        struct {
+			Name         string `json:"name"`
+			EmailAddress string `json:"emailAddress"`
+			Active       bool   `json:"active"`
+			DisplayName  string `json:"displayName"`
+			ID           int    `json:"id"`
+			Slug         string `json:"slug"`
+			Type         string `json:"type"`
+			Links        struct {
+				Self []struct {
+					Href string `json:"href"`
+				} `json:"self"`
+			} `json:"links"`
+		} `json:"user"`
+		Action           string `json:"action"`
+		FromHash         string `json:"fromHash,omitempty"`
+		PreviousFromHash string `json:"previousFromHash,omitempty"`
+		PreviousToHash   string `json:"previousToHash,omitempty"`
+		ToHash           string `json:"toHash,omitempty"`
+		Added            struct {
+			Commits []struct {
+				ID        string `json:"id"`
+				DisplayID string `json:"displayId"`
+				Author    struct {
+					Name         string `json:"name"`
+					EmailAddress string `json:"emailAddress"`
+					Active       bool   `json:"active"`
+					DisplayName  string `json:"displayName"`
+					ID           int    `json:"id"`
+					Slug         string `json:"slug"`
+					Type         string `json:"type"`
+					Links        struct {
+						Self []struct {
+							Href string `json:"href"`
+						} `json:"self"`
+					} `json:"links"`
+				} `json:"author"`
+				AuthorTimestamp int64 `json:"authorTimestamp"`
+				Committer       struct {
+					Name         string `json:"name"`
+					EmailAddress string `json:"emailAddress"`
+					Active       bool   `json:"active"`
+					DisplayName  string `json:"displayName"`
+					ID           int    `json:"id"`
+					Slug         string `json:"slug"`
+					Type         string `json:"type"`
+					Links        struct {
+						Self []struct {
+							Href string `json:"href"`
+						} `json:"self"`
+					} `json:"links"`
+				} `json:"committer"`
+				CommitterTimestamp int64  `json:"committerTimestamp"`
+				Message            string `json:"message"`
+				Parents            []struct {
+					ID        string `json:"id"`
+					DisplayID string `json:"displayId"`
+				} `json:"parents"`
+				Properties struct {
+					JiraKey []string `json:"jira-key"`
+				} `json:"properties"`
+			} `json:"commits"`
+			Total int `json:"total"`
+		} `json:"added,omitempty"`
+		Removed struct {
+			Commits []interface{} `json:"commits"`
+			Total   int           `json:"total"`
+		} `json:"removed,omitempty"`
+		CancelledReason string  `json:"cancelledReason,omitempty"`
+		CommentAction   string  `json:"commentAction,omitempty"`
+		Comment         Comment `json:"comment,omitempty"`
+		CommentAnchor   struct {
+			FromHash string `json:"fromHash"`
+			ToHash   string `json:"toHash"`
+			Line     int    `json:"line"`
+			LineType string `json:"lineType"`
+			FileType string `json:"fileType"`
+			Path     string `json:"path"`
+			DiffType string `json:"diffType"`
+			Orphaned bool   `json:"orphaned"`
+		} `json:"commentAnchor,omitempty"`
+		Diff struct {
+			Source      interface{} `json:"source"`
+			Destination struct {
+				Components []string `json:"components"`
+				Parent     string   `json:"parent"`
+				Name       string   `json:"name"`
+				Extension  string   `json:"extension"`
+				ToString   string   `json:"toString"`
+			} `json:"destination"`
+			Hunks []struct {
+				SourceLine      int `json:"sourceLine"`
+				SourceSpan      int `json:"sourceSpan"`
+				DestinationLine int `json:"destinationLine"`
+				DestinationSpan int `json:"destinationSpan"`
+				Segments        []struct {
+					Type  string `json:"type"`
+					Lines []struct {
+						Destination int    `json:"destination"`
+						Source      int    `json:"source"`
+						Line        string `json:"line"`
+						Repository  bool   `json:"repository"`
+					} `json:"lines"`
+					Truncated bool `json:"truncated"`
+				} `json:"segments"`
+				Truncated bool `json:"truncated"`
+			} `json:"hunks"`
+			Truncated  bool `json:"truncated"`
+			Properties struct {
+				ToHash   string `json:"toHash"`
+				Current  bool   `json:"current"`
+				FromHash string `json:"fromHash"`
+			} `json:"properties"`
+		} `json:"diff,omitempty"`
+	} `json:"values"`
+	Start int `json:"start"`
+}

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -59,7 +59,7 @@ type Comment struct {
 	Author      User          `json:"author"`
 	CreatedDate int64         `json:"createdDate"`
 	UpdatedDate int64         `json:"updatedDate"`
-	Comments    []interface{} `json:"comments"`
+	Comments    []*Comment    `json:"comments"`
 	Tasks       []interface{} `json:"tasks"`
 }
 

--- a/service/bitbucket.go
+++ b/service/bitbucket.go
@@ -35,6 +35,16 @@ func (b *Bitbucket) CanMerge(project, repoSlug string, prID int) (models.Merge, 
 	return merge, err
 }
 
+/** Returns activity data for a PR */
+func (b *Bitbucket) GetPrActivity(project string, repoSlug string, prID int) (models.Activities, error) {
+	u := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/activities", project, repoSlug, prID)
+	activities := models.Activities{}
+	err := b.do("GET", u, nil, &activities)
+
+	return activities, err
+
+}
+
 type ErrorResponse struct {
 	Errors []struct {
 		Context       interface{} `json:"context"`

--- a/service/notifier_test.go
+++ b/service/notifier_test.go
@@ -1,0 +1,180 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/fortnoxab/bitbucket-slack-bot/models"
+	"github.com/nlopes/slack"
+)
+
+type Author struct {
+	email   string
+	slackId string
+}
+
+var FallbackUser = Author{
+	email:   "fallback.user@example.com",
+	slackId: "slack-fallback-user",
+}
+var PrAuthor = Author{
+	email:   "pr.author@example.com",
+	slackId: "slack-id-author",
+}
+var PreviousThreadCommenter1 = Author{
+	email:   "thread.commenter1@example.com",
+	slackId: "slack-id-thread-commenter1",
+}
+var PreviousThreadCommenter2 = Author{
+	email:   "thread.commenter2@example.com",
+	slackId: "slack-id-thread-commenter2",
+}
+
+type MockSlackGerUserByEmail struct {
+	CalledWith                     []string
+	ReturnFallbackUser             *slack.User
+	ReturnErr                      error
+	ReturnPrAuthor                 *slack.User
+	ReturnPreviousThreadCommenter1 *slack.User
+	ReturnPreviousThreadCommenter2 *slack.User
+	ReturnLastCommenter            *slack.User
+}
+
+func (m *MockSlackGerUserByEmail) call(email string) (*slack.User, error) {
+	m.CalledWith = append(m.CalledWith, email)
+	switch email {
+	case PrAuthor.email:
+		return m.ReturnPrAuthor, m.ReturnErr
+	case PreviousThreadCommenter1.email:
+		return m.ReturnPreviousThreadCommenter1, m.ReturnErr
+	case PreviousThreadCommenter2.email:
+		return m.ReturnPreviousThreadCommenter2, m.ReturnErr
+	default:
+		return m.ReturnFallbackUser, m.ReturnErr
+	}
+}
+
+type MockSlackPostMessage struct {
+	CalledWith []struct {
+		ChannelID string
+		Options   []slack.MsgOption
+	}
+	ReturnTimestamp string
+	ReturnMsgID     string
+	ReturnErr       error
+}
+
+func (m *MockSlackPostMessage) call(channelID string, options ...slack.MsgOption) (string, string, error) {
+	m.CalledWith = append(m.CalledWith, struct {
+		ChannelID string
+		Options   []slack.MsgOption
+	}{channelID, options})
+
+	return m.ReturnTimestamp, m.ReturnMsgID, m.ReturnErr
+}
+
+type MockBitbucketGetPrActivity struct {
+	CalledWith []struct {
+		project  string
+		repoSlug string
+		prId     int
+	}
+	ReturnActivities models.Activities
+	ReturnErr        error
+}
+
+func (m *MockBitbucketGetPrActivity) call(project string, repoSlug string, prId int) (models.Activities, error) {
+	m.CalledWith = append(m.CalledWith, struct {
+		project  string
+		repoSlug string
+		prId     int
+	}{project, repoSlug, prId})
+	return m.ReturnActivities, m.ReturnErr
+}
+
+/*
+This test verifies the logic for notifying bitbucket PR thread participants through slack
+The mock webhooks and pr_activities responses contain the following case:
+
+	[thread] comment 1 (author: PrAuthor)
+		[thread] comment 2 (author: ThreadCommenter1)
+			[thread] comment 3 (author: ThreadCommenter2)
+				[thread] comment 4 (author: ThreadCommenter3) <- new comment that triggers the webhook
+
+3 users must be notified once (not ThreadCommenter3, since he posted the comment):
+  - PrAuthor
+  - ThreadCommenter1
+  - ThreadCommenter2
+*/
+func TestPrCommentAdded(t *testing.T) {
+	expect := func(msg string, received any, expected any) {
+		if expected != received {
+			t.Errorf("❌ %s [actual/expect] \"%s\" / \"%s\"", msg, received, expected)
+		} else {
+			// fmt.Printf("✅ %s\n", msg)
+		}
+	}
+
+	prActivitiesJSON, err1 := os.ReadFile("../testdata/pr_activities_mock.json")
+	webhookBodyJSON, err2 := os.ReadFile("../testdata/webhook_body_mock.json")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("failed to read fixtures")
+	}
+	var prActivitiesMock models.Activities
+	var webhookBodyMock models.WebhookBody
+	if err := json.Unmarshal(prActivitiesJSON, &prActivitiesMock); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+	if err := json.Unmarshal(webhookBodyJSON, &webhookBodyMock); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	mockSlackGerUserByEmail := &MockSlackGerUserByEmail{
+		ReturnFallbackUser: &slack.User{
+			ID: FallbackUser.slackId,
+		},
+		ReturnPrAuthor: &slack.User{
+			ID: PrAuthor.slackId,
+		},
+		ReturnPreviousThreadCommenter1: &slack.User{
+			ID: PreviousThreadCommenter1.slackId,
+		},
+		ReturnPreviousThreadCommenter2: &slack.User{
+			ID: PreviousThreadCommenter2.slackId,
+		},
+		ReturnErr: nil,
+	}
+
+	mockSlackPostMessage := &MockSlackPostMessage{
+		ReturnTimestamp: "0",
+		ReturnMsgID:     "1",
+		ReturnErr:       nil,
+	}
+
+	mockBitbucketGetPrActivity := &MockBitbucketGetPrActivity{
+		ReturnActivities: prActivitiesMock,
+		ReturnErr:        nil,
+	}
+
+	// should return different users based on their email
+	f, _ := mockSlackGerUserByEmail.call(FallbackUser.email)
+	expect("should load fallback user ", FallbackUser.slackId, f.ID)
+	p, _ := mockSlackGerUserByEmail.call(PrAuthor.email)
+	expect("should load PR author user ", PrAuthor.slackId, p.ID)
+	t1, _ := mockSlackGerUserByEmail.call(PreviousThreadCommenter1.email)
+	expect("should load ThreadCommenter1 user ", PreviousThreadCommenter1.slackId, t1.ID)
+	t2, _ := mockSlackGerUserByEmail.call(PreviousThreadCommenter2.email)
+	expect("should load ThreadCommenter2 user ", PreviousThreadCommenter2.slackId, t2.ID)
+
+	prCommentAdded(
+		mockSlackGerUserByEmail.call,
+		mockSlackPostMessage.call,
+		mockBitbucketGetPrActivity.call,
+		&webhookBodyMock)
+
+	expect("should notify PR author", mockSlackPostMessage.CalledWith[0].ChannelID, PrAuthor.slackId)
+	expect("should notify previous thread commenter 1", mockSlackPostMessage.CalledWith[1].ChannelID, PreviousThreadCommenter1.slackId)
+	expect("should notify previous thread commenter 2", mockSlackPostMessage.CalledWith[2].ChannelID, PreviousThreadCommenter2.slackId)
+	expect("should NOT double notify or notify the author of last comment (thread commenter 3)", len(mockSlackPostMessage.CalledWith), 3)
+}

--- a/testdata/pr_activities_mock.json
+++ b/testdata/pr_activities_mock.json
@@ -1,0 +1,933 @@
+{
+  "size": 25,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "id": 5702638,
+      "createdDate": 1748938768880,
+      "user": {
+        "name": "pr.author",
+        "emailAddress": "pr.author@example.com",
+        "active": true,
+        "displayName": "Pr Author",
+        "id": 1357,
+        "slug": "pr.author",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/users/pr.author"
+            }
+          ]
+        }
+      },
+      "action": "COMMENTED",
+      "commentAction": "ADDED",
+      "comment": {
+        "properties": {
+          "repositoryId": 242
+        },
+        "id": 1001,
+        "version": 1,
+        "text": "First comment in thread, by Pr Author!",
+        "author": {
+          "name": "thread.commenter1",
+          "emailAddress": "thread.commenter1@example.com",
+          "active": true,
+          "displayName": "Thread Commenter1",
+          "id": 1357,
+          "slug": "thread.commenter1",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.some-company.se/users/thread.commenter1"
+              }
+            ]
+          }
+        },
+        "createdDate": 1748938768878,
+        "updatedDate": 1748938768878,
+        "comments": [
+          {
+            "properties": {
+              "repositoryId": 242
+            },
+            "id": 1002,
+            "version": 1,
+            "text": "Second comment in thread by ThreadCommenter1!",
+            "author": {
+              "name": "thread.commenter1",
+              "emailAddress": "thread.commenter1@example.com",
+              "active": true,
+              "displayName": "Thread Commenter1",
+              "id": 1357,
+              "slug": "thread.commenter1",
+              "type": "NORMAL",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/users/thread.commenter1"
+                  }
+                ]
+              }
+            },
+            "createdDate": 1748938768878,
+            "updatedDate": 1748938768878,
+            "comments": [
+              {
+                "properties": {
+                  "repositoryId": 242
+                },
+                "id": 1003,
+                "version": 0,
+                "text": "Third comment in thread by ThreadCommenter2!",
+                "author": {
+                  "name": "thread.commenter2",
+                  "emailAddress": "thread.commenter2@example.com",
+                  "active": true,
+                  "displayName": "Thread Commenter2",
+                  "id": 334,
+                  "slug": "thread.commenter2",
+                  "type": "NORMAL",
+                  "links": {
+                    "self": [
+                      {
+                        "href": "https://git.some-company.se/users/thread.commenter2"
+                      }
+                    ]
+                  }
+                },
+                "createdDate": 1748954698961,
+                "updatedDate": 1748954698961,
+                "comments": [
+                  {
+                    "properties": {
+                      "repositoryId": 242
+                    },
+                    "id": 1004,
+                    "version": 0,
+                    "text": "Forth and NEW comment in thread!",
+                    "author": {
+                      "name": "thread.commenter3",
+                      "emailAddress": "thread.commenter3@example.com",
+                      "active": true,
+                      "displayName": "Thread Commenter3",
+                      "id": 334,
+                      "slug": "thread.commenter3",
+                      "type": "NORMAL",
+                      "links": {
+                        "self": [
+                          {
+                            "href": "https://git.some-company.se/users/thread.commenter3"
+                          }
+                        ]
+                      }
+                    },
+                    "createdDate": 1748954698961,
+                    "updatedDate": 1748954698961,
+                    "comments": [],
+                    "threadResolved": true,
+                    "severity": "NORMAL",
+                    "state": "OPEN",
+                    "permittedOperations": {
+                      "editable": false,
+                      "transitionable": true,
+                      "deletable": false
+                    }
+                  }
+                ],
+                "threadResolved": true,
+                "severity": "NORMAL",
+                "state": "OPEN",
+                "permittedOperations": {
+                  "editable": false,
+                  "transitionable": true,
+                  "deletable": false
+                }
+              }
+            ],
+            "threadResolved": true,
+            "severity": "BLOCKER",
+            "state": "RESOLVED",
+            "permittedOperations": {
+              "editable": true,
+              "transitionable": true,
+              "deletable": true
+            },
+            "resolvedDate": 1748955233636,
+            "resolver": {
+              "name": "thread.commenter1",
+              "emailAddress": "thread.commenter1@example.com",
+              "active": true,
+              "displayName": "Thread Commenter1",
+              "id": 1357,
+              "slug": "thread.commenter1",
+              "type": "NORMAL",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/users/thread.commenter1"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "threadResolved": true,
+        "severity": "BLOCKER",
+        "state": "RESOLVED",
+        "permittedOperations": {
+          "editable": true,
+          "transitionable": true,
+          "deletable": true
+        },
+        "resolvedDate": 1748955233636
+      },
+
+      "commentAnchor": {
+        "fromHash": "a8b0f5c82524fc8a2f9a01370f795df4bd46472b",
+        "toHash": "e19f982b9d914df1f565b45c22bb7ffbea163b57",
+        "line": 12,
+        "lineType": "ADDED",
+        "fileType": "TO",
+        "path": "ui/src/features/customer-rating/components/CustomerRating.tsx",
+        "diffType": "EFFECTIVE",
+        "orphaned": false
+      },
+      "diff": {
+        "source": null,
+        "destination": {
+          "components": [
+            "ui",
+            "src",
+            "features",
+            "customer-rating",
+            "components",
+            "CustomerRating.tsx"
+          ],
+          "parent": "ui/src/features/customer-rating/components",
+          "name": "CustomerRating.tsx",
+          "extension": "tsx",
+          "toString": "ui/src/features/customer-rating/components/CustomerRating.tsx"
+        },
+        "hunks": [
+          {
+            "sourceLine": 4,
+            "sourceSpan": 20,
+            "destinationLine": 4,
+            "destinationSpan": 19,
+            "segments": [
+              {
+                "type": "CONTEXT",
+                "lines": [
+                  {
+                    "destination": 4,
+                    "source": 4,
+                    "line": "import { nullable, z } from 'zod';",
+                    "repository": false
+                  },
+                  {
+                    "destination": 5,
+                    "source": 5,
+                    "line": "import { CustomerRatingModal } from './CustomerRateModal';",
+                    "repository": false
+                  },
+                  {
+                    "destination": 6,
+                    "source": 6,
+                    "line": "import { getFid } from 'features/metrics-sender';",
+                    "repository": false
+                  },
+                  {
+                    "destination": 7,
+                    "source": 7,
+                    "line": "",
+                    "repository": false
+                  },
+                  {
+                    "destination": 8,
+                    "source": 8,
+                    "line": "const ratingTypes = z.enum(['rating', 'ces']);",
+                    "repository": false
+                  },
+                  {
+                    "destination": 9,
+                    "source": 9,
+                    "line": "",
+                    "repository": false
+                  }
+                ],
+                "truncated": false
+              },
+              {
+                "type": "REMOVED",
+                "lines": [
+                  {
+                    "destination": 10,
+                    "source": 10,
+                    "line": "// eslint-disable-next-line @typescript-eslint/no-unused-vars",
+                    "repository": false
+                  }
+                ],
+                "truncated": false
+              },
+              {
+                "type": "CONTEXT",
+                "lines": [
+                  {
+                    "destination": 10,
+                    "source": 11,
+                    "line": "const Survey = z.object({",
+                    "repository": false
+                  },
+                  {
+                    "destination": 11,
+                    "source": 12,
+                    "line": "\tid: z.string(),",
+                    "repository": false
+                  }
+                ],
+                "truncated": false
+              },
+              {
+                "type": "REMOVED",
+                "lines": [
+                  {
+                    "destination": 12,
+                    "source": 13,
+                    "line": "\tdescription: z.string(),",
+                    "repository": false
+                  }
+                ],
+                "truncated": false
+              },
+              {
+                "type": "ADDED",
+                "lines": [
+                  {
+                    "destination": 12,
+                    "source": 14,
+                    "line": "\tmessageQuestion: nullable(z.string()),",
+                    "repository": false,
+                    "commentIds": [500036]
+                  }
+                ],
+                "truncated": false
+              },
+              {
+                "type": "CONTEXT",
+                "lines": [
+                  {
+                    "destination": 13,
+                    "source": 14,
+                    "line": "\tview: nullable(z.string()),",
+                    "repository": false
+                  },
+                  {
+                    "destination": 14,
+                    "source": 15,
+                    "line": "\tratingVariant: nullable(ratingTypes),",
+                    "repository": false
+                  },
+                  {
+                    "destination": 15,
+                    "source": 16,
+                    "line": "\tfeatureSwitches: nullable(z.array(z.string())),",
+                    "repository": false
+                  },
+                  {
+                    "destination": 16,
+                    "source": 17,
+                    "line": "\twaitingSeconds: nullable(z.number()),",
+                    "repository": false
+                  },
+                  {
+                    "destination": 17,
+                    "source": 18,
+                    "line": "});",
+                    "repository": false
+                  },
+                  {
+                    "destination": 18,
+                    "source": 19,
+                    "line": "",
+                    "repository": false
+                  },
+                  {
+                    "destination": 19,
+                    "source": 20,
+                    "line": "export type SurveyType = z.infer<typeof Survey>;",
+                    "repository": false
+                  },
+                  {
+                    "destination": 20,
+                    "source": 21,
+                    "line": "",
+                    "repository": false
+                  },
+                  {
+                    "destination": 21,
+                    "source": 22,
+                    "line": "let timeout: NodeJS.Timeout | null = null;",
+                    "repository": false
+                  },
+                  {
+                    "destination": 22,
+                    "source": 23,
+                    "line": "",
+                    "repository": false
+                  }
+                ],
+                "truncated": false
+              }
+            ],
+            "truncated": false
+          }
+        ],
+        "truncated": false,
+        "properties": {
+          "toHash": "e19f982b9d914df1f565b45c22bb7ffbea163b57",
+          "current": true,
+          "fromHash": "a8b0f5c82524fc8a2f9a01370f795df4bd46472b"
+        }
+      }
+    },
+
+    {
+      "id": 5702456,
+      "createdDate": 1748937910450,
+      "user": {
+        "name": "john.doe",
+        "emailAddress": "john.doe@example.com",
+        "active": true,
+        "displayName": "John Doe",
+        "id": 3026,
+        "slug": "john.doe",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/users/john.doe"
+            }
+          ]
+        }
+      },
+      "action": "COMMENTED",
+      "commentAction": "ADDED",
+      "comment": {
+        "properties": {
+          "repositoryId": 242
+        },
+        "id": 500017,
+        "version": 0,
+        "text": "The PR",
+        "author": {
+          "name": "john.doe",
+          "emailAddress": "john.doe@example.com",
+          "active": true,
+          "displayName": "John Doe",
+          "id": 3026,
+          "slug": "john.doe",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.some-company.se/users/john.doe"
+              }
+            ]
+          }
+        },
+        "createdDate": 1748937910448,
+        "updatedDate": 1748937910448,
+        "comments": [],
+        "threadResolved": false,
+        "severity": "NORMAL",
+        "state": "OPEN",
+        "permittedOperations": {
+          "editable": false,
+          "transitionable": true,
+          "deletable": false
+        }
+      }
+    },
+    {
+      "id": 5702105,
+      "createdDate": 1748936047491,
+      "user": {
+        "name": "checklistbuddy",
+        "active": true,
+        "displayName": "Checklist Buddy",
+        "emailAddress": null,
+        "id": 3337,
+        "slug": "checklistbuddy",
+        "type": "SERVICE",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/bots/checklistbuddy"
+            }
+          ]
+        }
+      },
+      "action": "COMMENTED",
+      "commentAction": "ADDED",
+      "comment": {
+        "properties": {
+          "repositoryId": 242
+        },
+        "id": 499981,
+        "version": 0,
+        "text": "**[CHECKLISTBUDDY](https://marketplace.atlassian.com/apps/1225571/pull-request-checklist-buddy-for-bitbucket?hosting=datacenter&tab=overview) PR checklist** ✅",
+        "author": {
+          "name": "checklistbuddy",
+          "active": true,
+          "displayName": "Checklist Buddy",
+          "emailAddress": null,
+          "id": 3337,
+          "slug": "checklistbuddy",
+          "type": "SERVICE",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.some-company.se/bots/checklistbuddy"
+              }
+            ]
+          }
+        },
+        "createdDate": 1748936047488,
+        "updatedDate": 1748936047488,
+        "comments": [
+          {
+            "properties": {
+              "repositoryId": 242
+            },
+            "id": 499982,
+            "version": 1,
+            "text": "I have read the [contribution guidelines](https://git.some-company.se/projects/FNX/repos/vessel/browse/CONTRIBUTING.md).",
+            "author": {
+              "name": "checklistbuddy",
+              "active": true,
+              "displayName": "Checklist Buddy",
+              "emailAddress": null,
+              "id": 3337,
+              "slug": "checklistbuddy",
+              "type": "SERVICE",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/bots/checklistbuddy"
+                  }
+                ]
+              }
+            },
+            "createdDate": 1748936047511,
+            "updatedDate": 1748936047511,
+            "comments": [],
+            "threadResolved": false,
+            "severity": "BLOCKER",
+            "state": "RESOLVED",
+            "permittedOperations": {
+              "editable": false,
+              "transitionable": true,
+              "deletable": false
+            },
+            "resolvedDate": 1748936049434,
+            "resolver": {
+              "name": "thread.commenter2",
+              "emailAddress": "thread.commenter2@example.com",
+              "active": true,
+              "displayName": "Thread Commenter2",
+              "id": 334,
+              "slug": "thread.commenter2",
+              "type": "NORMAL",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/users/thread.commenter2"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "repositoryId": 242
+            },
+            "id": 499983,
+            "version": 1,
+            "text": "I acknowledge that that branches will be **directly merged** UNLESS tagged with [DRAFT] in the title.",
+            "author": {
+              "name": "checklistbuddy",
+              "active": true,
+              "displayName": "Checklist Buddy",
+              "emailAddress": null,
+              "id": 3337,
+              "slug": "checklistbuddy",
+              "type": "SERVICE",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/bots/checklistbuddy"
+                  }
+                ]
+              }
+            },
+            "createdDate": 1748936047531,
+            "updatedDate": 1748936047531,
+            "comments": [],
+            "threadResolved": false,
+            "severity": "BLOCKER",
+            "state": "RESOLVED",
+            "permittedOperations": {
+              "editable": false,
+              "transitionable": true,
+              "deletable": false
+            },
+            "resolvedDate": 1748936050430,
+            "resolver": {
+              "name": "thread.commenter2",
+              "emailAddress": "thread.commenter2@example.com",
+              "active": true,
+              "displayName": "Thread Commenter2",
+              "id": 334,
+              "slug": "thread.commenter2",
+              "type": "NORMAL",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/users/thread.commenter2"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "repositoryId": 242
+            },
+            "id": 499984,
+            "version": 1,
+            "text": "I acknowledge that PRs will be **automatically released** into production 36h after they are merged (earliest). EXPLICITLY contact #frontend-developers to prevent that.",
+            "author": {
+              "name": "checklistbuddy",
+              "active": true,
+              "displayName": "Checklist Buddy",
+              "emailAddress": null,
+              "id": 3337,
+              "slug": "checklistbuddy",
+              "type": "SERVICE",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/bots/checklistbuddy"
+                  }
+                ]
+              }
+            },
+            "createdDate": 1748936047570,
+            "updatedDate": 1748936047570,
+            "comments": [],
+            "threadResolved": false,
+            "severity": "BLOCKER",
+            "state": "RESOLVED",
+            "permittedOperations": {
+              "editable": false,
+              "transitionable": true,
+              "deletable": false
+            },
+            "resolvedDate": 1748936051019,
+            "resolver": {
+              "name": "thread.commenter2",
+              "emailAddress": "thread.commenter2@example.com",
+              "active": true,
+              "displayName": "Thread Commenter2",
+              "id": 334,
+              "slug": "thread.commenter2",
+              "type": "NORMAL",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/users/thread.commenter2"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "repositoryId": 242
+            },
+            "id": 499985,
+            "version": 1,
+            "text": "I acknowledge that Vessel's **release cadence** is Tuesday and Thursday midday, EXCEPT for critical bugfixes.",
+            "author": {
+              "name": "checklistbuddy",
+              "active": true,
+              "displayName": "Checklist Buddy",
+              "emailAddress": null,
+              "id": 3337,
+              "slug": "checklistbuddy",
+              "type": "SERVICE",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/bots/checklistbuddy"
+                  }
+                ]
+              }
+            },
+            "createdDate": 1748936047593,
+            "updatedDate": 1748936047593,
+            "comments": [],
+            "threadResolved": false,
+            "severity": "BLOCKER",
+            "state": "RESOLVED",
+            "permittedOperations": {
+              "editable": false,
+              "transitionable": true,
+              "deletable": false
+            },
+            "resolvedDate": 1748936051656,
+            "resolver": {
+              "name": "thread.commenter2",
+              "emailAddress": "thread.commenter2@example.com",
+              "active": true,
+              "displayName": "Thread Commenter2",
+              "id": 334,
+              "slug": "thread.commenter2",
+              "type": "NORMAL",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/users/thread.commenter2"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "repositoryId": 242
+            },
+            "id": 499986,
+            "version": 0,
+            "text": "All done? merge PR with `--squash`",
+            "author": {
+              "name": "checklistbuddy",
+              "active": true,
+              "displayName": "Checklist Buddy",
+              "emailAddress": null,
+              "id": 3337,
+              "slug": "checklistbuddy",
+              "type": "SERVICE",
+              "links": {
+                "self": [
+                  {
+                    "href": "https://git.some-company.se/bots/checklistbuddy"
+                  }
+                ]
+              }
+            },
+            "createdDate": 1748936047634,
+            "updatedDate": 1748936047634,
+            "comments": [],
+            "threadResolved": false,
+            "severity": "NORMAL",
+            "state": "OPEN",
+            "permittedOperations": {
+              "editable": false,
+              "transitionable": true,
+              "deletable": false
+            }
+          }
+        ],
+        "threadResolved": false,
+        "severity": "NORMAL",
+        "state": "OPEN",
+        "permittedOperations": {
+          "editable": false,
+          "transitionable": true,
+          "deletable": false
+        }
+      }
+    },
+    {
+      "id": 5708063,
+      "createdDate": 1749019390241,
+      "user": {
+        "name": "bob.sponge",
+        "emailAddress": "bob.sponge@example.com",
+        "active": true,
+        "displayName": "Bob Sponge",
+        "id": 2469,
+        "slug": "bob.sponge",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/users/bob.sponge"
+            }
+          ]
+        }
+      },
+      "action": "MERGED",
+      "commit": {
+        "id": "1dd8dae8266e14d1f6be4fa59029e8f33eee0961",
+        "displayId": "1dd8dae8266",
+        "author": {
+          "name": "thread.commenter2",
+          "emailAddress": "thread.commenter2@example.com",
+          "active": true,
+          "displayName": "Thread Commenter2",
+          "id": 334,
+          "slug": "thread.commenter2",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.some-company.se/users/thread.commenter2"
+              }
+            ]
+          }
+        },
+        "authorTimestamp": 1749019390000,
+        "committer": {
+          "name": "bob.sponge",
+          "emailAddress": "bob.sponge@example.com",
+          "active": true,
+          "displayName": "Bob Sponge",
+          "id": 2469,
+          "slug": "bob.sponge",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.some-company.se/users/bob.sponge"
+              }
+            ]
+          }
+        },
+        "committerTimestamp": 1749019390000,
+        "message": "Pull request #2436",
+        "parents": [
+          {
+            "id": "20896d97b330555929ba4bcbb704a90468a2be83",
+            "displayId": "20896d97b33",
+            "author": {
+              "name": "Renovate-bot Renovate-bot",
+              "emailAddress": "renovate-bot@example.com"
+            },
+            "authorTimestamp": 1748957445000,
+            "committer": {
+              "name": "Bob Sponge",
+              "emailAddress": "bob.sponge@example.com"
+            },
+            "committerTimestamp": 1748957445000,
+            "message": "Pull request #2437",
+            "parents": [
+              {
+                "id": "0c919309c2abef185694daa6efe1a66f9ec397c7",
+                "displayId": "0c919309c2a"
+              },
+              {
+                "id": "0552ddde7a0cac5f980efae08e688a6109842e2c",
+                "displayId": "0552ddde7a0"
+              }
+            ]
+          },
+          {
+            "id": "e19f982b9d914df1f565b45c22bb7ffbea163b57",
+            "displayId": "e19f982b9d9",
+            "author": {
+              "name": "Thread Commenter2",
+              "emailAddress": "thread.commenter2@example.com"
+            },
+            "authorTimestamp": 1748960854000,
+            "committer": {
+              "name": "Thread Commenter2",
+              "emailAddress": "thread.commenter2@example.com"
+            },
+            "committerTimestamp": 1748960854000,
+            "message": "ECHO-35 add param to get endpoint",
+            "parents": [
+              {
+                "id": "e2defc8fe14e9dad1eeab991832e36ca5149903a",
+                "displayId": "e2defc8fe14"
+              }
+            ]
+          }
+        ],
+        "properties": {
+          "jira-key": ["ECHO-35"]
+        }
+      },
+      "autoMerge": false
+    },
+    {
+      "id": 5708060,
+      "createdDate": 1749019379018,
+      "user": {
+        "name": "bob.sponge",
+        "emailAddress": "bob.sponge@example.com",
+        "active": true,
+        "displayName": "Bob Sponge",
+        "id": 2469,
+        "slug": "bob.sponge",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/users/bob.sponge"
+            }
+          ]
+        }
+      },
+      "action": "APPROVED"
+    },
+    {
+      "id": 5706535,
+      "createdDate": 1748966913577,
+      "user": {
+        "name": "thread.commenter1",
+        "emailAddress": "thread.commenter1@example.com",
+        "active": true,
+        "displayName": "Thread Commenter1",
+        "id": 1357,
+        "slug": "thread.commenter1",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/users/thread.commenter1"
+            }
+          ]
+        }
+      },
+      "action": "APPROVED"
+    },
+    {
+      "id": 5702103,
+      "createdDate": 1748936047349,
+      "user": {
+        "name": "pr.author",
+        "emailAddress": "pr.author@example.com",
+        "active": true,
+        "displayName": "Pr Author",
+        "id": 334,
+        "slug": "pr.author",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://git.some-company.se/users/pr.author"
+            }
+          ]
+        }
+      },
+      "action": "OPENED"
+    }
+  ],
+  "start": 0
+}

--- a/testdata/webhook_body_mock.json
+++ b/testdata/webhook_body_mock.json
@@ -1,0 +1,155 @@
+{
+  "bitbucketURL": "https://bitbucket.example.com",
+  "eventKey": "pr:comment:added",
+  "date": "2025-06-06T12:34:56Z",
+  "actor": {
+    "name": "PreviousThreadCommenter2",
+    "emailAddress": "thread.commenter2@example.com",
+    "id": 101,
+    "displayName": "PreviousThreadCommenter2",
+    "active": true,
+    "slug": "PreviousThreadCommenter2",
+    "type": "NORMAL"
+  },
+  "pullRequest": {
+    "id": 42,
+    "version": 1,
+    "title": "Add feature XYZ",
+    "description": "This pull request adds feature XYZ.",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1717651200000,
+    "updatedDate": 1717654800000,
+    "locked": false,
+    "toRef": {
+      "id": "refs/heads/main",
+      "displayId": "main",
+      "latestCommit": "abcdef1234567890",
+      "repository": {
+        "slug": "my-repo",
+        "id": 1,
+        "name": "My Repository",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "PRJ",
+          "id": 99,
+          "name": "My Project",
+          "public": false,
+          "type": "NORMAL"
+        },
+        "public": false
+      }
+    },
+    "fromRef": {
+      "id": "refs/heads/feature/xyz",
+      "displayId": "feature/xyz",
+      "latestCommit": "123456abcdef7890",
+      "repository": {
+        "slug": "my-repo",
+        "id": 1,
+        "name": "My Repository",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "PRJ",
+          "id": 99,
+          "name": "My Project",
+          "public": false,
+          "type": "NORMAL"
+        },
+        "public": false
+      }
+    },
+    "author": {
+      "user": {
+        "name": "Pr Author",
+        "emailAddress": "pr.author@example.com",
+        "id": 101,
+        "displayName": "Pr Author",
+        "active": true,
+        "slug": "prauthor",
+        "type": "NORMAL"
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [
+      {
+        "user": {
+          "name": "asmith",
+          "emailAddress": "asmith@example.com",
+          "id": 102,
+          "displayName": "Alice Smith",
+          "active": true,
+          "slug": "asmith",
+          "type": "NORMAL"
+        },
+        "lastReviewedCommit": "abcdef1234567890",
+        "role": "REVIEWER",
+        "approved": true,
+        "status": "APPROVED"
+      }
+    ],
+    "participants": []
+  },
+  "comment": {
+    "properties": {
+      "repositoryId": 242
+    },
+    "id": 1004,
+    "version": 0,
+    "text": "Third and NEW comment in thread!",
+    "author": {
+      "name": "thread.commenter3",
+      "emailAddress": "thread.commenter3@example.com",
+      "active": true,
+      "displayName": "Thread Commenter3",
+      "id": 334,
+      "slug": "thread.commenter3",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://git.some-company.se/users/thread.commenter3"
+          }
+        ]
+      }
+    },
+    "createdDate": 1748954698961,
+    "updatedDate": 1748954698961,
+    "comments": [],
+    "threadResolved": true,
+    "severity": "NORMAL",
+    "state": "OPEN",
+    "permittedOperations": {
+      "editable": false,
+      "transitionable": true,
+      "deletable": false
+    }
+  },
+  "participant": {
+    "user": {
+      "name": "asmith",
+      "emailAddress": "asmith@example.com",
+      "id": 102,
+      "displayName": "Alice Smith",
+      "active": true,
+      "slug": "asmith",
+      "type": "NORMAL"
+    },
+    "lastReviewedCommit": "abcdef1234567890",
+    "role": "REVIEWER",
+    "approved": true,
+    "status": "APPROVED"
+  },
+  "previousStatus": "UNAPPROVED",
+  "addedReviewers": [],
+  "removedReviewers": []
+}


### PR DESCRIPTION
This is my first attempt at writing go, feedback is welcome 🙂 

The main change other than the thread notification bit, is that the `prCommentAdded` method now uses dependency injection through function parameters (for easier testing and mocking). 

When users get a slack notification due to a thread udpate, the thread's comment URL has been added to the notification too.

In order to get as close as possible to bitbuckets response format, the mock API responses are stored as JSON in `testdata` folder.  The test reads and unmarshal's them into `models`.
