### PR TITLE
Patch thread notifications

### DIFF
--- a/service/notifier.go
+++ b/service/notifier.go
@@ -163,7 +163,7 @@ func prCommentAdded(
 					return err
 				}
 
-				commentUrl := fmt.Sprintf("%s/projects/%s/repos/%s/pull-requests/%d/overview?commentId=%d/",
+				commentUrl := fmt.Sprintf("%s/projects/%s/repos/%s/pull-requests/%d/overview?commentId=%d",
 					b.BitbucketURL,
 					b.PullRequest.ToRef.Repository.Project.Key,
 					b.PullRequest.ToRef.Repository.Slug,

--- a/service/notifier.go
+++ b/service/notifier.go
@@ -124,15 +124,16 @@ func prCommentAdded(
 	// Notify PR author
 	if b.Actor.Name == b.PullRequest.Author.User.Name { // dont notify yourself
 		logrus.Debug("Skip notifying author is same as actor")
-		return nil
-	}
-	user, err := slackGetUserByEmail(b.PullRequest.Author.User.EmailAddress)
-	if err != nil {
-		return err
-	}
-	_, _, err = slackPostMessage(user.ID, b.FormatMessage(b.Comment.Text, "commented")...)
-	if err != nil {
-		return err
+	} else {
+		user, err := slackGetUserByEmail(b.PullRequest.Author.User.EmailAddress)
+		if err != nil {
+			logrus.Printf("Skip notifying, slack user %s not found", b.PullRequest.Author.User.EmailAddress)
+		} else {
+			_, _, err = slackPostMessage(user.ID, b.FormatMessage(b.Comment.Text, "commented")...)
+			if err != nil {
+				logrus.Printf("Failed to notify user %s with slack id: %s ", b.PullRequest.Author.User.EmailAddress, user.ID)
+			}
+		}
 	}
 
 	// Notify comment thread


### PR DESCRIPTION
Current implementation works well, but has 2 issues that the PR fixes:
- the comment URL is malformed
- if the PR is created by a bot, the `prCommentAdded` function exits early, as the `slackGetUserByEmail` will fail. The expected behaviour is that the thread commenters should be notified, regardless of who created the PR.
